### PR TITLE
fix(ci): Correct Windows CLI artifact path for cross-compiled builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,11 @@ jobs:
         shell: bash
         run: |
           mkdir -p cli-artifacts
-          cp src-tauri/target/release/mcp-hub-stdio.exe cli-artifacts/mcp-hub-stdio-${{ matrix.rust_target }}.exe
+          if [ "${{ matrix.rust_target }}" != "" ]; then
+            cp src-tauri/target/${{ matrix.rust_target }}/release/mcp-hub-stdio.exe cli-artifacts/mcp-hub-stdio-${{ matrix.rust_target }}.exe
+          else
+            cp src-tauri/target/release/mcp-hub-stdio.exe cli-artifacts/mcp-hub-stdio.exe
+          fi
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions build failure on Windows by correcting the CLI artifact path.

**Root Cause:** The Windows build step was copying from `src-tauri/target/release/mcp-hub-stdio.exe`, but when building with `--target x86_64-pc-windows-msvc`, cargo outputs to `src-tauri/target/x86_64-pc-windows-msvc/release/mcp-hub-stdio.exe`.

**Fix:** Updated the "Prepare CLI artifacts (Windows)" step to check if `rust_target` is specified and use the appropriate path, mirroring the existing Unix artifact handling logic.

## Changes

- Modified `.github/workflows/release.yml` to use target-specific path when `rust_target` is set

## Testing Completed

- [x] Verified the Unix step already handles this correctly (lines 117-122)
- [x] Confirmed Windows matrix entry has `rust_target: x86_64-pc-windows-msvc`
- [x] Fix mirrors the pattern used in the Unix step

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)