### PR TITLE
fix: Add proxy server auto-start on application launch

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub fn run() {
 
     // Clone for setup hook
     let discovery_server_setup = discovery_server.clone();
+    let proxy_server_setup = proxy_server.clone();
     let db_for_setup = Database::new(
         services::config::get_database_path().expect("Failed to determine database path"),
     )
@@ -48,6 +49,7 @@ pub fn run() {
         .setup(move |_app| {
             // Initialize discovery services based on saved settings
             let discovery_server = discovery_server_setup.clone();
+            let proxy_server = proxy_server_setup.clone();
 
             tauri::async_runtime::spawn(async move {
                 // Load settings
@@ -86,6 +88,23 @@ pub fn run() {
                         }
                         Err(e) => {
                             log::error!("Failed to start discovery HTTP server: {}", e);
+                        }
+                    }
+                }
+
+                // Start proxy server if auto_start is enabled
+                if settings.proxy.auto_start {
+                    match services::proxy::start_proxy_server(settings.proxy.port).await {
+                        Ok(handle) => {
+                            let mut guard = proxy_server.write().await;
+                            *guard = Some(handle);
+                            log::info!(
+                                "MCP Proxy server auto-started on port {}",
+                                settings.proxy.port
+                            );
+                        }
+                        Err(e) => {
+                            log::error!("Failed to auto-start proxy server: {}", e);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- Adds proxy server auto-start logic to the Tauri setup hook
- When `settings.proxy.auto_start` is enabled, the proxy server now starts automatically on app launch
- Previously only the discovery server was auto-started; the proxy server was missing

## Technical Changes

In `src-tauri/src/lib.rs`:
- Clone `proxy_server` handle for use in setup hook
- Add proxy auto-start block that mirrors the discovery server auto-start pattern
- Logs success/failure of proxy server startup

## Testing Completed

- [x] `cargo check` passes
- [x] Verified code mirrors existing discovery server pattern
- [x] Logic correctly checks `settings.proxy.auto_start` before starting

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)