### PR TITLE
fix: Add deduplication when importing servers

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -282,11 +282,24 @@ pub fn import_from_file(state: State<AppState>, path: String) -> Result<Vec<McpS
     let servers = config::import_servers_from_config(&path)?;
 
     let db = state.db.lock().map_err(|e| e.to_string())?;
-    for server in &servers {
-        db.create_server(server).map_err(|e| e.to_string())?;
+
+    // Get existing server names for deduplication (case-insensitive)
+    let existing_servers = db.get_all_servers().map_err(|e| e.to_string())?;
+    let existing_names: std::collections::HashSet<String> = existing_servers
+        .iter()
+        .map(|s| s.name.to_lowercase())
+        .collect();
+
+    // Only import servers that don't already exist
+    let mut imported = Vec::new();
+    for server in servers {
+        if !existing_names.contains(&server.name.to_lowercase()) {
+            db.create_server(&server).map_err(|e| e.to_string())?;
+            imported.push(server);
+        }
     }
 
-    Ok(servers)
+    Ok(imported)
 }
 
 #[tauri::command]
@@ -505,12 +518,22 @@ pub fn import_from_registry(
     servers: Vec<services::registry::RegistryServer>,
 ) -> Result<Vec<McpServer>, String> {
     let db = state.db.lock().map_err(|e| e.to_string())?;
-    let mut imported = Vec::new();
 
+    // Get existing server names for deduplication (case-insensitive)
+    let existing_servers = db.get_all_servers().map_err(|e| e.to_string())?;
+    let existing_names: std::collections::HashSet<String> = existing_servers
+        .iter()
+        .map(|s| s.name.to_lowercase())
+        .collect();
+
+    // Only import servers that don't already exist
+    let mut imported = Vec::new();
     for registry_server in servers {
         let server = services::registry::registry_server_to_mcp_server(&registry_server, &registry_id);
-        db.create_server(&server).map_err(|e| e.to_string())?;
-        imported.push(server);
+        if !existing_names.contains(&server.name.to_lowercase()) {
+            db.create_server(&server).map_err(|e| e.to_string())?;
+            imported.push(server);
+        }
     }
 
     Ok(imported)


### PR DESCRIPTION
## Summary

Fixes a bug where importing servers from clients or registries would create duplicates if servers with the same name already existed.

### Changes

Both `import_from_file` and `import_from_registry` now:
1. Get existing server names from the database
2. Use case-insensitive comparison to check for duplicates
3. Skip servers that already exist
4. Return only the actually-imported servers

This ensures the success message ("Imported N servers") accurately reflects new additions.

## Testing Completed

- [x] Rust compiles successfully (`cargo check`)
- [x] Verified deduplication logic with HashSet for O(1) lookups

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>