### PR TITLE
[#31] Fix: Editing server name creates duplicate instead of updating

### DIFF
--- a/src/pages/Servers.tsx
+++ b/src/pages/Servers.tsx
@@ -120,7 +120,9 @@ export function Servers() {
 
   const handleOpenDialog = (server?: McpServer) => {
     if (server) {
+      // Editing an existing server - ensure clean state
       setEditingServer(server);
+      setDuplicatingFromId(null); // Clear any stale duplication state
       setFormData({
         name: server.name,
         description: server.description || "",
@@ -132,7 +134,9 @@ export function Servers() {
         tags: server.tags.join(", "),
       });
     } else {
+      // Adding a new server
       setEditingServer(null);
+      setDuplicatingFromId(null);
       setFormData(emptyFormData);
     }
     setIsDialogOpen(true);
@@ -143,6 +147,16 @@ export function Servers() {
     setEditingServer(null);
     setFormData(emptyFormData);
     setDuplicatingFromId(null);
+  };
+
+  // Handle dialog open state changes (including Escape/click-outside dismissal)
+  const handleDialogOpenChange = (open: boolean) => {
+    if (!open) {
+      // Dialog is being closed - reset all editing state
+      handleCloseDialog();
+    } else {
+      setIsDialogOpen(true);
+    }
   };
 
   const handleSubmit = async () => {
@@ -386,7 +400,7 @@ export function Servers() {
       )}
 
       {/* Add/Edit Dialog */}
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <Dialog open={isDialogOpen} onOpenChange={handleDialogOpenChange}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
             <DialogTitle>


### PR DESCRIPTION
## Summary

- Fixed an issue where editing a server's name could result in creating a duplicate server instead of updating the existing one
- The root cause was improper state management in the dialog component
- When the dialog was dismissed via Escape or clicking outside, editing state was not properly reset

## Changes Made

1. Added `handleDialogOpenChange` handler to properly reset all editing state when dialog closes by any method
2. Modified `handleOpenDialog` to explicitly clear `duplicatingFromId` when editing existing servers
3. Added comments for code clarity

## Testing

- [x] Frontend builds successfully (`pnpm build`)
- [x] Rust compiles successfully (`cargo check`)
- [ ] Manual testing: Edit a server's name and verify it updates instead of creating duplicate
- [ ] Manual testing: Open edit dialog, press Escape, then add new server - verify no stale state

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)