### PR TITLE
[#33] Rename sidebar 'Instances' to 'Clients'

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,7 +13,7 @@ import { useStore } from "@/store";
 const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Servers", href: "/servers", icon: Server },
-  { name: "Instances", href: "/instances", icon: Layers },
+  { name: "Clients", href: "/instances", icon: Layers },
   { name: "Settings", href: "/settings", icon: Settings },
 ];
 
@@ -72,7 +72,7 @@ export function Layout() {
             disabled={instances.length === 0}
           >
             <RefreshCw className="w-4 h-4" />
-            Sync All Instances
+            Sync All Clients
           </Button>
         </div>
       </aside>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -101,7 +101,7 @@ export function Dashboard() {
           <CardContent>
             <div className="text-2xl font-bold">{recentlySynced.length}</div>
             <p className="text-xs text-muted-foreground">
-              Instances up to date
+              Clients up to date
             </p>
           </CardContent>
         </Card>
@@ -113,7 +113,7 @@ export function Dashboard() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{needsSync.length}</div>
-            <p className="text-xs text-muted-foreground">Instances pending</p>
+            <p className="text-xs text-muted-foreground">Clients pending</p>
           </CardContent>
         </Card>
       </div>
@@ -135,7 +135,7 @@ export function Dashboard() {
             <Button variant="outline" asChild>
               <Link to="/instances">
                 <Layers className="w-4 h-4 mr-2" />
-                Manage Instances
+                Manage Clients
               </Link>
             </Button>
             <Button


### PR DESCRIPTION
## Summary

Updated UI text to use "Clients" terminology instead of "Instances" for improved clarity and consistency.

## Changes Made

- Sidebar navigation: "Instances" → "Clients"
- Sync button: "Sync All Instances" → "Sync All Clients"
- Dashboard stats: "Instances up to date" → "Clients up to date"
- Dashboard stats: "Instances pending" → "Clients pending"
- Quick action: "Manage Instances" → "Manage Clients"

## Testing

- [x] Frontend builds successfully (`pnpm build`)
- [ ] Visual verification: Sidebar shows "Clients" instead of "Instances"

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)